### PR TITLE
chore(server): add retryOnInitFail

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -116,7 +116,8 @@ const postgraphileOptions = {
   enhanceGraphiql: true,
   disableQueryLog: !isDev,
   showErrorStack: isDev,
-  extendedErrors: isDev ? POSTGRAPHILE_ERRORS_TO_SHOW : ["errcode"]
+  extendedErrors: isDev ? POSTGRAPHILE_ERRORS_TO_SHOW : ["errcode"],
+  retryOnInitFail: true
 };
 const server = http
   .createServer(


### PR DESCRIPTION
When I want to start a fresh stack with the database, its migrations and the graphql server. The GQL server tries to connect to the database before the migrations are fully applied.

By adding the flag `retryOnInitFail`, the GQL server will retry to connect periodically until the migrations are finished.